### PR TITLE
Fix Fungle electrical sabotage initialization

### DIFF
--- a/TheOtherRoles/Objects/Map/FungleElectrical.cs
+++ b/TheOtherRoles/Objects/Map/FungleElectrical.cs
@@ -14,9 +14,12 @@ public static class FungleAdditionalElectrical
             FungleShipStatus fungleShipStatus = ShipStatus.Instance.CastFast<FungleShipStatus>();
             SwitchSystem system = new();
             fungleShipStatus.Systems[SystemTypes.Electrical] = system.TryCast<ISystemType>();
+            MapUtilities.RefreshSystems(fungleShipStatus);
             fungleShipStatus.Systems[SystemTypes.Sabotage].TryCast<SabotageSystemType>().specials.Add(system.TryCast<IActivatable>());
-            List<PlayerTask> Tasks = VanillaAsset.MapAsset[3].SpecialTasks.ToList();
-            Tasks.Add(MapLoader.Airship?.SpecialTasks?.FirstOrDefault(x => x.TaskType == TaskTypes.FixLights) ?? Tasks.FirstOrDefault(x => x.TaskType == TaskTypes.FixLights));
+            List<PlayerTask> Tasks = ShipStatus.Instance.SpecialTasks.ToList();
+            PlayerTask fixLightsTask = MapLoader.Airship?.SpecialTasks?.FirstOrDefault(x => x.TaskType == TaskTypes.FixLights);
+            if (fixLightsTask != null && !Tasks.Any(x => x.TaskType == TaskTypes.FixLights))
+                Tasks.Add(fixLightsTask);
             ShipStatus.Instance.SpecialTasks = new(Tasks.ToArray());
 
             Console console1 = UObject.Instantiate(VanillaAsset.MapAsset[3].transform.FindChild("Storage/task_lightssabotage (cargo)"), fungleShipStatus.transform).GetComponent<Console>();

--- a/TheOtherRoles/Options/CustomOptionHolder.cs
+++ b/TheOtherRoles/Options/CustomOptionHolder.cs
@@ -782,6 +782,7 @@ public class CustomOptionHolder
     public static CustomOption modifierButtonBarry;
     public static CustomOption buttonBarryCanBeGuessed;
     public static CustomOption modifierButtonSabotageRemoteMeetings;
+    public static CustomOption buttonBarryCanBeJester;
 
     public static CustomOption modifierWatcher;
     public static CustomOption watcherCanBeGuessed;
@@ -1743,6 +1744,7 @@ public class CustomOptionHolder
         modifierButtonBarry = Create(402800, Types.Modifier, Cs(Color.yellow, "ButtonBarry"), rates, null, true);
         buttonBarryCanBeGuessed = Create(400026, Types.Modifier, "modifierCanBeGuessed", true, modifierButtonBarry, isHidden: () => !AllowGuessModifier.GetBool());
         modifierButtonSabotageRemoteMeetings = Create(402801, Types.Modifier, "modifierButtonSabotageRemoteMeetings", true, modifierButtonBarry);
+        buttonBarryCanBeJester = Create(402802, Types.Modifier, "buttonBarryCanBeJester", false, modifierButtonBarry);
 
         modifierSlueth = Create(402900, Types.Modifier, Cs(Color.yellow, "Slueth"), rates, null, true);
         sluethCanBeGuessed = Create(400027, Types.Modifier, "modifierCanBeGuessed", true, modifierSlueth, isHidden: () => !AllowGuessModifier.GetBool());

--- a/TheOtherRoles/Patches/RoleAssignmentPatch.cs
+++ b/TheOtherRoles/Patches/RoleAssignmentPatch.cs
@@ -1035,6 +1035,8 @@ internal class RoleManagerSelectRolesPatch
         {
             var buttonPlayer = new List<PlayerControl>(playerList);
             buttonPlayer.RemoveAll(x => x == Mayor.mayor);
+            if (!CustomOptionHolder.buttonBarryCanBeJester.GetBool())
+                buttonPlayer.RemoveAll(x => Jester.Player.Any(jester => jester.PlayerId == x.PlayerId));
 
             playerId = setModifierToRandomPlayer((byte)RoleId.ButtonBarry, buttonPlayer);
             crewPlayer.RemoveAll(x => x.PlayerId == playerId);

--- a/TheOtherRoles/Resources/stringData.json
+++ b/TheOtherRoles/Resources/stringData.json
@@ -2796,6 +2796,10 @@
         "0": "Can Call Emergency Meetings during Sabotages",
         "13": "可在破坏时使用"
     },
+    "buttonBarryCanBeJester": {
+        "0": "Jester Can Be Button Barry",
+        "13": "小丑可以获得执钮人"
+    },
     "modifierAutoJoin": {
         "0": "Auto-joins the Imposters if the Impostor Team Gains Majority",
         "13": "在伪装者人数占优时自动加入"

--- a/TheOtherRoles/Utilities/MapUtilities.cs
+++ b/TheOtherRoles/Utilities/MapUtilities.cs
@@ -15,6 +15,13 @@ public static class MapUtilities
         }
     }
 
+    public static void RefreshSystems(ShipStatus shipStatus)
+    {
+        CachedShipStatus = shipStatus;
+        _systems.Clear();
+        GetSystems();
+    }
+
     public static void MapDestroyed()
     {
         CachedShipStatus = ShipStatus.Instance;


### PR DESCRIPTION
## 修改内容

- 保留 The Fungle 原有的 `SpecialTasks`，只追加非空且未重复的 Airship `FixLights` 任务。
- 动态注入 Electrical 系统后立即刷新 `MapUtilities.Systems` 缓存。

## 原因

v1.2.7 将 Fungle 的整套特殊任务错误替换为空艇任务，导致 Mushroom Mixup 等原生破坏任务丢失。同时，Electrical 在开场后动态加入时，已初始化的系统缓存不会刷新，可能在光照计算中持续抛出缺键异常并写日志，造成严重掉帧。

## 影响

修复 Fungle 启用附加电力系统后触发破坏时可能出现的任务初始化异常和 3–4 FPS 卡顿。

## 验证

- `.NET 10: dotnet build TheOtherRoles.sln --no-restore`
- 构建结果：0 warnings / 0 errors
- `git diff --check` 通过